### PR TITLE
Enables chemical substitutions

### DIFF
--- a/edit_me.ts
+++ b/edit_me.ts
@@ -1,9 +1,11 @@
 import { calculate } from './formulas/calculator';
 // import { chlorineFormula } from './formulas/formulas/chlorine';
 import { saltFormula } from './formulas/formulas/salt';
+import { TreatmentSubs } from './formulas/models/misc/DeltaTreatment';
 import { ReadingValues } from './formulas/models/misc/Values';
 import { Pool } from './formulas/models/pool/Pool';
 import { EffectiveTargetRange } from './formulas/models/TargetRange';
+import { calc_hypo } from './formulas/treatments/calc_hypo';
 
 const formula = saltFormula;
 
@@ -22,11 +24,18 @@ const readings: ReadingValues = {
 
 const targetLevels: EffectiveTargetRange[] = [];
 
+const substitutions: TreatmentSubs = {
+    'fc': {
+        up: calc_hypo,
+    }
+};
+
 const res = calculate({
     formula,
     pool,
     readings,
     targetLevels,
+    substitutions,
 });
 
 console.log('Results:');

--- a/formulas/calculator.ts
+++ b/formulas/calculator.ts
@@ -1,6 +1,7 @@
 /// This runs a formula and returns some results!
 
 import { Formula } from './models/Formula';
+import { TreatmentSubs } from './models/misc/DeltaTreatment';
 import { avg, isIn } from './models/misc/Range';
 import { EffectiveTargetRanges, EffectValues, ReadingValues, TreatmentValues } from './models/misc/Values';
 import { Pool } from './models/pool/Pool';
@@ -12,6 +13,7 @@ export interface FormulaRunRequest {
     formula: Formula;
     readings: ReadingValues;
     targetLevels: EffectiveTargetRange[];   // TODO: reconsider this!
+    substitutions: TreatmentSubs;
     pool: Pool;
 }
 
@@ -99,8 +101,12 @@ export const calculate = (req: FormulaRunRequest): TreatmentValues => {
         const delta = deltas[dt.reading_id];
         if (!delta) { return; }
 
-        const t = (delta > 0) ? dt.up : dt.down;
-        // TODO: resolve substitutes here
+        let t: Treatment | null;
+        if (delta > 0) {
+            t = req.substitutions[dt.reading_id]?.up ?? dt.up;
+        } else {
+            t = req.substitutions[dt.reading_id]?.down ?? dt.down;
+        }
 
         if (!!t) {
             executeTreatmentFunction(t);

--- a/formulas/formulas/australian.ts
+++ b/formulas/formulas/australian.ts
@@ -20,6 +20,7 @@ import { phosphate } from '../readings/phosphate';
 import { phosphate_rem } from '../treatments/phosphate_rem';
 import { na_clo } from '../treatments/na_clo';
 import { m_acid } from '../treatments/m_acid';
+import { DT } from '../models/Helpers';
 
 /// This is the default formula for pools with a chlorinator:
 export const australianFormula: Formula = {
@@ -44,14 +45,15 @@ export const australianFormula: Formula = {
     adjusters: [
         breakpointFCAdjuster
     ],
-    treatments: [
-        na_clo,
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
-        cya_treatment,
+    balanceOrder: [
+        DT('fc', na_clo, null),
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('cya', cya_treatment, null),
+        DT('phosphate', phosphate_rem, null),
+    ],
+    alwaysCheck: [
         lsi,
-        phosphate_rem
     ],
 };

--- a/formulas/formulas/bromine.ts
+++ b/formulas/formulas/bromine.ts
@@ -44,7 +44,7 @@ export const bromineFormula: Formula = {
         DT('ta', baking_soda, m_acid),
         DT('ch', cal_chlor, null),
         DT('cya', cya_treatment, null),
-        DT('phosphate', phosphate_rem, null),
+        DT('phosphate', null, phosphate_rem),
     ],
     alwaysCheck: [
         lsi,

--- a/formulas/formulas/bromine.ts
+++ b/formulas/formulas/bromine.ts
@@ -15,6 +15,9 @@ import { cya as cya_treatment } from '../treatments/cya';
 import { m_acid } from '../treatments/m_acid';
 import { soda_ash } from '../treatments/soda_ash';
 import { bromine } from '../treatments/bromine';
+import { DT } from '../models/Helpers';
+import { phosphate_rem } from '../treatments/phosphate_rem';
+import { phosphate } from '../readings/phosphate';
 
 
 export const bromineFormula: Formula = {
@@ -30,17 +33,20 @@ export const bromineFormula: Formula = {
         cya_reading,
         temp_f,
         temp_c,
-        tds
+        tds,
+        phosphate,
     ],
     targets: [],
     adjusters: [],
-    treatments: [
-        bromine,
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
-        cya_treatment,
+    balanceOrder: [
+        DT('bro', bromine, null),
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('cya', cya_treatment, null),
+        DT('phosphate', phosphate_rem, null),
+    ],
+    alwaysCheck: [
         lsi,
-    ]
+    ],
 };

--- a/formulas/formulas/chlorine.ts
+++ b/formulas/formulas/chlorine.ts
@@ -20,6 +20,7 @@ import { breakpointFCAdjuster } from '../adjusters/breakpoint';
 import { ccTarget } from '../targets/ccTarget';
 import { phosphate } from '../readings/phosphate';
 import { phosphate_rem } from '../treatments/phosphate_rem';
+import { DT } from '../models/Helpers';
 
 
 /// This is the default formula for pools with a chlorinator:
@@ -45,14 +46,15 @@ export const chlorineFormula: Formula = {
     adjusters: [
         breakpointFCAdjuster
     ],
-    treatments: [
-        calc_hypo,
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
-        cya_treatment,
+    balanceOrder: [
+        DT('fc', calc_hypo, null),
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('cya', cya_treatment, null),
+        DT('phosphate', null, phosphate_rem),
+    ],
+    alwaysCheck: [
         lsi,
-        phosphate_rem
     ],
 };

--- a/formulas/formulas/dichlor.ts
+++ b/formulas/formulas/dichlor.ts
@@ -1,25 +1,14 @@
 import { Formula } from '~/formulas/models/Formula';
-import { ch } from '~/formulas/readings/ch';
-import { cya as cya_reading } from '~/formulas/readings/cya';
-import { fc } from '~/formulas/readings/fc';
-import { ph } from '~/formulas/readings/ph';
-import { ta } from '~/formulas/readings/ta';
-import { tc } from '~/formulas/readings/tc';
-import { tds } from '~/formulas/readings/tds';
-import { temp_c } from '~/formulas/readings/temp_c';
-import { temp_f } from '~/formulas/readings/temp_f';
 import { baking_soda } from '~/formulas/treatments/baking_soda';
 
 import { cal_chlor } from '~/formulas/treatments/cal_chlor';
-import { lsi } from '~/formulas/treatments/lsi';
 import { m_acid } from '~/formulas/treatments/m_acid';
 import { soda_ash } from '~/formulas/treatments/soda_ash';
 import { cya as cya_treatment } from '~/formulas/treatments/cya';
-import { breakpointFCAdjuster } from '../adjusters/breakpoint';
-import { ccTarget } from '../targets/ccTarget';
-import { phosphate } from '../readings/phosphate';
 import { phosphate_rem } from '../treatments/phosphate_rem';
 import { dichlor } from '../treatments/dichlor';
+import { chlorineFormula } from './chlorine';
+import { DT } from '../models/Helpers';
 
 
 /// This is the default formula for pools with a chlorinator:
@@ -27,32 +16,16 @@ export const dichlorFormula: Formula = {
     name: 'Dichlor',
     description: 'This is for pools with a chlorinator that prefer Dichloro-S-Triazinetrione as the granule shock.',
     id: 'dichlor',
-    readings: [
-        fc,
-        tc,
-        ph,
-        ta,
-        ch,
-        cya_reading,
-        temp_f,
-        temp_c,
-        tds,
-        phosphate
+    readings: chlorineFormula.readings,
+    targets: chlorineFormula.targets,
+    adjusters: chlorineFormula.adjusters,
+    balanceOrder: [
+        DT('fc', dichlor, null),        // This is the only difference w/ chlorineFormula, we should rethink this formula system
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('cya', cya_treatment, null),
+        DT('phosphate', null, phosphate_rem),
     ],
-    targets: [
-        ccTarget
-    ],
-    adjusters: [
-        breakpointFCAdjuster
-    ],
-    treatments: [
-        dichlor,
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
-        cya_treatment,
-        lsi,
-        phosphate_rem
-    ],
+    alwaysCheck: chlorineFormula.alwaysCheck,
 };

--- a/formulas/formulas/ecosmarte.ts
+++ b/formulas/formulas/ecosmarte.ts
@@ -14,6 +14,7 @@ import { disox } from '../readings/disox';
 import { phosphate_rem } from '../treatments/phosphate_rem';
 import { ionizer } from '../treatments/ionizer';
 import { oxidizer } from '../treatments/oxidizer';
+import { DT } from '../models/Helpers';
 
 
 /// This is the default formula for pools with a chlorinator:
@@ -31,13 +32,15 @@ export const ecoSmarteFormula: Formula = {
     ],
     targets: [],
     adjusters: [],
-    treatments: [
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
+    balanceOrder: [
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('phosphate', null, phosphate_rem),
+    ],
+    alwaysCheck: [
         lsi,
-        phosphate_rem,
+        // TODO: move these 2 to "balanceOrder"?
         ionizer,
         oxidizer,
     ],

--- a/formulas/formulas/salt.ts
+++ b/formulas/formulas/salt.ts
@@ -1,6 +1,7 @@
 import { Formula } from '~/formulas/models/Formula';
 import { ch } from '~/formulas/readings/ch';
 import { cya as cya_reading } from '~/formulas/readings/cya';
+import { cya as cya_treatment } from '../treatments/cya';
 import { fc } from '~/formulas/readings/fc';
 import { ph } from '~/formulas/readings/ph';
 import { ta } from '~/formulas/readings/ta';
@@ -14,7 +15,6 @@ import { cal_chlor } from '~/formulas/treatments/cal_chlor';
 import { lsi } from '~/formulas/treatments/lsi';
 import { m_acid } from '~/formulas/treatments/m_acid';
 import { soda_ash } from '~/formulas/treatments/soda_ash';
-import { cya as cya_treatment } from '~/formulas/treatments/cya';
 import { swg_up } from '~/formulas/treatments/swg_up';
 import { swg_down } from '~/formulas/treatments/swg_down';
 import { phosphate_rem } from '~/formulas/treatments/phosphate_rem';
@@ -23,6 +23,7 @@ import { ccTarget } from '../targets/ccTarget';
 import { breakpointFCAdjuster } from '../adjusters/breakpoint';
 import { salt as salt_reading } from '../readings/salt';
 import { salt as salt_treatment } from '../treatments/salt';
+import { DT } from '../models/Helpers';
 
 
 /// This is the default formula for salt-water pools:
@@ -48,17 +49,18 @@ export const saltFormula: Formula = {
     adjusters: [
         breakpointFCAdjuster
     ],
-    treatments: [
-        dichlor,
-        soda_ash,
-        baking_soda,
-        m_acid,
-        cal_chlor,
-        cya_treatment,
-        salt_treatment,
+    balanceOrder: [
+        DT('fc', dichlor, null),
+        DT('ph', soda_ash, m_acid),
+        DT('ta', baking_soda, m_acid),
+        DT('ch', cal_chlor, null),
+        DT('cya', cya_treatment, null),
+        DT('salt', salt_treatment, null),
+        DT('phosphate', null, phosphate_rem),
+    ],
+    alwaysCheck: [
         lsi,
         swg_up,
         swg_down,
-        phosphate_rem
     ],
 };

--- a/formulas/formulas/uv.ts
+++ b/formulas/formulas/uv.ts
@@ -20,5 +20,6 @@ export const uvFormula: Formula = {
         }
     ],
     adjusters: chlorineFormula.adjusters,
-    treatments: chlorineFormula.treatments
+    balanceOrder: chlorineFormula.balanceOrder,
+    alwaysCheck: chlorineFormula.alwaysCheck,
 };

--- a/formulas/models/Formula.ts
+++ b/formulas/models/Formula.ts
@@ -3,6 +3,7 @@ import { Reading } from './Reading';
 import { Treatment } from './Treatment';
 import { FormulaID } from './FormulaID';
 import { GetUpdatedReadingsAndDeltas } from './misc/UpdatedTargets';
+import { DeltaTreatment } from './misc/DeltaTreatment';
 
 /**
  * Attempts to codify the instructions for a specific type of pool maintenance.
@@ -22,8 +23,12 @@ export interface Formula {
     // The readings to take
     readings: Reading[];
 
+    // Defines both the ordering of which deltas are treated, and the default treatments associated with each effect.
+    // The treatments for each effect can be overridden via substitutes.
+    balanceOrder: DeltaTreatment[];
+
     // The possible treatments to apply (each of these includes a formula)
-    treatments: Treatment[];
+    alwaysCheck: Treatment[];
 
     // Any overrides to the default target ranges. These can still be overridden again by the end-user.
     targets: TargetRange[];

--- a/formulas/models/Helpers.ts
+++ b/formulas/models/Helpers.ts
@@ -1,0 +1,11 @@
+import { DeltaTreatment } from './misc/DeltaTreatment';
+import { Treatment } from './Treatment';
+
+/// Syntactic sugar to construct a DeltaTreatment with less code:
+export const DT = (reading_id: string, up: Treatment | null, down: Treatment | null): DeltaTreatment => {
+    return {
+        reading_id,
+        up,
+        down
+    };
+};

--- a/formulas/models/misc/DeltaTreatment.ts
+++ b/formulas/models/misc/DeltaTreatment.ts
@@ -1,0 +1,16 @@
+import { Treatment } from '../Treatment';
+
+
+/// For a given reading, how should we try to effect it?
+export interface DeltaTreatment {
+    /// The id of the reading to effect
+    reading_id: string;
+    /// The treatment to raise the reading.
+    up: Treatment | null;
+    /// The treatment to lower the reading.
+    down: Treatment | null;
+}
+
+
+/// For convenience, we sometimes access these by reading_id
+export type DeltaTreatmentMap = Record<string, DeltaTreatment>;

--- a/formulas/models/misc/DeltaTreatment.ts
+++ b/formulas/models/misc/DeltaTreatment.ts
@@ -12,5 +12,5 @@ export interface DeltaTreatment {
 }
 
 
-/// For convenience, we sometimes access these by reading_id
-export type DeltaTreatmentMap = Record<string, DeltaTreatment>;
+/// We define substitutions by mapping reading_id: up | down.
+export type TreatmentSubs = Record<string, Omit<Partial<DeltaTreatment>, 'reading_id'>>;

--- a/formulas/util.ts
+++ b/formulas/util.ts
@@ -16,7 +16,7 @@ export class Util {
             return cp.map((n: any) => Util.deepCopy<any>(n)) as any;
         }
 
-        if (typeof target === 'object' && target !== {}) {
+        if (typeof target === 'object') {
             const cp = { ...(target as { [key: string]: any }) } as { [key: string]: any };
             Object.keys(cp).forEach((k) => {
                 cp[k] = Util.deepCopy<any>(cp[k]);
@@ -51,7 +51,7 @@ export class Util {
 
     static getDisplayNameForTreatment = (t: { name: string; concentration?: number }): string => {
         if (t.concentration && t.concentration < 100) {
-            return `${t.concentration.toFixed(0)}% ${t.name}`;
+            return `${ t.concentration.toFixed(0) }% ${ t.name }`;
         } else {
             return t.name;
         }
@@ -92,7 +92,7 @@ export class Util {
         if (volume < 1000) {
             return volume.toFixed(0);
         }
-        return `${(volume / 1000).toFixed(0)}K`;
+        return `${ (volume / 1000).toFixed(0) }K`;
     };
 
     static generateTimestamp = () => {

--- a/tests/core/subs.test.ts
+++ b/tests/core/subs.test.ts
@@ -1,0 +1,105 @@
+import { calculate } from '~/formulas/calculator';
+import { ReadingValues } from '~/formulas/models/misc/Values';
+import { EffectiveTargetRange } from '~/formulas/models/TargetRange';
+import { getDummyFormula, getDummyTreatment, getPool } from '../helpers/testHelpers';
+
+/*  This should be the formula under test  */
+const formula = getDummyFormula();
+
+// Note: a lot of these tests depend on getDummyFormula() having specific params,
+// make sure you take a look at the "balanceOrder" & "alwaysCheck" properties there.
+describe('Calculate', () => {
+    it('uses formula-default treatments when no subs given', () => {
+        // Arrange
+        const pool = getPool();
+        const targetLevels: EffectiveTargetRange[] = [];
+        const readings: ReadingValues = {
+            a: 0,
+            b: 100,
+        };
+
+        // Act
+        const res = calculate({
+            formula,
+            pool,
+            readings,
+            targetLevels,
+            substitutions: {},
+        });
+
+        // Assert
+        expect(Object.keys(res).length).toBe(2);
+        expect(res.x).toBeCloseTo(1);
+        expect(res.z).toBeCloseTo(1);
+    });
+
+    it('uses substitutes when provided for correct directions', () => {
+        // Arrange
+        const pool = getPool();
+        const targetLevels: EffectiveTargetRange[] = [];
+        const readings: ReadingValues = {
+            a: 0,
+            b: 100,
+        };
+        const v = {
+            ...getDummyTreatment(),
+            id: 'v',
+        };
+        const w = {
+            ...getDummyTreatment(),
+            id: 'w',
+        };
+
+        // Act
+        const res = calculate({
+            formula,
+            pool,
+            readings,
+            targetLevels,
+            substitutions: {
+                a: { up: v },
+                b: { down: w }
+            },
+        });
+
+        // Assert
+        expect(Object.keys(res).length).toBe(3);
+        expect(res.v).toBeCloseTo(1);
+        expect(res.w).toBeCloseTo(1);
+        expect(res.z).toBeCloseTo(1);
+    });
+
+    it('ignores substitutes when readings are balanced', () => {
+        // Arrange
+        const pool = getPool();
+        const targetLevels: EffectiveTargetRange[] = [];
+        const readings: ReadingValues = {
+            a: 4,
+            b: 4,
+        };
+        const v = {
+            ...getDummyTreatment(),
+            id: 'v',
+        };
+        const w = {
+            ...getDummyTreatment(),
+            id: 'w',
+        };
+
+        // Act
+        const res = calculate({
+            formula,
+            pool,
+            readings,
+            targetLevels,
+            substitutions: {
+                a: { up: v },
+                b: { down: w }
+            },
+        });
+
+        // Assert
+        expect(Object.keys(res).length).toBe(1);
+        expect(res.z).toBeCloseTo(1);
+    });
+});

--- a/tests/formulas/bromine.test.ts
+++ b/tests/formulas/bromine.test.ts
@@ -29,6 +29,7 @@ describe('Bromine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -60,6 +61,7 @@ describe('Bromine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -88,6 +90,7 @@ describe('Bromine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert

--- a/tests/formulas/chlorine.test.ts
+++ b/tests/formulas/chlorine.test.ts
@@ -30,6 +30,7 @@ describe('Chlorine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -62,6 +63,7 @@ describe('Chlorine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -91,6 +93,7 @@ describe('Chlorine Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert

--- a/tests/formulas/chlorine.test.ts
+++ b/tests/formulas/chlorine.test.ts
@@ -2,6 +2,7 @@ import { calculate } from '~/formulas/calculator';
 import { chlorineFormula } from '~/formulas/formulas/chlorine';
 import { ReadingValues } from '~/formulas/models/misc/Values';
 import { EffectiveTargetRange } from '~/formulas/models/TargetRange';
+import { dichlor } from '~/formulas/treatments/dichlor';
 import { getPool } from '../helpers/testHelpers';
 
 /*  This should be the formula under test  */
@@ -99,5 +100,35 @@ describe('Chlorine Formula', () => {
         // Assert
         expect(Object.keys(res).length).toBe(1);
         expect(res.lsi).toBeCloseTo(0.052);
+    });
+
+    it('correctly substitutes dichlor when instructed to', () => {
+        // Arrange
+        const pool = getPool();
+        const targetLevels: EffectiveTargetRange[] = [];
+        const readings: ReadingValues = {
+            fc: 0,
+            ph: 0,
+            tc: 0,
+            ta: 0,
+            ch: 0,
+            cya: 0,
+            temp_f: 80,
+            tds: 0,
+            phosphate: 0,
+        };
+
+        // Act
+        const res = calculate({
+            formula,
+            pool,
+            readings,
+            targetLevels,
+            substitutions: { 'fc': { up: dichlor } },   // This is the change to input
+        });
+
+        // Assert
+        expect(Object.keys(res).length).toBe(5);
+        expect(res.dichlor).toBeCloseTo(5.04);
     });
 });

--- a/tests/formulas/ecosmarte.test.ts
+++ b/tests/formulas/ecosmarte.test.ts
@@ -29,6 +29,7 @@ describe('ECOsmarte Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -59,6 +60,7 @@ describe('ECOsmarte Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -86,6 +88,7 @@ describe('ECOsmarte Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert

--- a/tests/formulas/uv.test.ts
+++ b/tests/formulas/uv.test.ts
@@ -29,6 +29,7 @@ describe('UV Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -60,6 +61,7 @@ describe('UV Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert
@@ -88,6 +90,7 @@ describe('UV Formula', () => {
             pool,
             readings,
             targetLevels,
+            substitutions: {},
         });
 
         // Assert

--- a/tests/helpers/testHelpers.ts
+++ b/tests/helpers/testHelpers.ts
@@ -1,4 +1,7 @@
+import { Formula } from '~/formulas/models/Formula';
 import { Pool } from '~/formulas/models/pool/Pool';
+import { Reading } from '~/formulas/models/Reading';
+import { Treatment } from '~/formulas/models/Treatment';
 
 export const getPool = (): Pool => {
     const testPool: Omit<Pool, 'liters'> = {
@@ -9,5 +12,80 @@ export const getPool = (): Pool => {
     return {
         ...testPool,
         liters: testPool.gallons * 3.785411784,
+    };
+};
+
+export const getDummyTreatment = (): Treatment => {
+    return {
+        id: 'dummy',
+        name: 'Dummy Treatment',
+        type: 'dryChemical',
+        concentration: 100,
+        function: () => ({
+            amount: 1,
+            effects: {}
+        }),
+    };
+};
+
+export const getDummyReading = (): Reading => {
+    return {
+        id: 'dummy',
+        name: 'Dummy Treatment',
+        decimalPlaces: 1,
+        defaultValue: 3,
+        isDefaultOn: true,
+        offsetReadingId: null,
+        sliderRange: {
+            min: 0,
+            max: 10,
+        },
+        targetRange: {
+            min: 3,
+            max: 5,
+        },
+        type: 'number',
+        units: 'ppm',
+    };
+};
+
+
+export const getDummyFormula = (): Formula => {
+    return {
+        id: 'chlorine_cal_hypo',    // Has to technically be valid
+        name: 'Test Formula',
+        description: 'test',
+        adjusters: [],
+        targets: [],
+        readings: [
+            {
+                ...getDummyReading(),
+                id: 'a',
+            }, {
+                ...getDummyReading(),
+                id: 'b',
+            }, {
+                ...getDummyReading(),
+                id: 'c',
+            }
+        ],
+        balanceOrder: [
+            {
+                reading_id: 'a',
+                up: { ...getDummyTreatment(), id: 'x' },
+                down: null,
+            },
+            {
+                reading_id: 'b',
+                up: { ...getDummyTreatment(), id: 'y' },
+                down: null,
+            }
+        ],
+        alwaysCheck: [
+            {
+                ...getDummyTreatment(),
+                id: 'z',
+            }
+        ]
     };
 };


### PR DESCRIPTION
Booyah!

This mostly just updates the core engine to allow for substitutes in formulas. There will be some follow-ups to make this more usable.

Out of scope:
1) Providing a list of "Get all the treatments that can <raise|lower> <reading_id>.

2) Providing friendly, colloquial names / brands / etc...